### PR TITLE
🔀 :: (#13) 기록 작성 버그수정

### DIFF
--- a/Projects/App/Entitlements/FlowApp.entitlements
+++ b/Projects/App/Entitlements/FlowApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.flow-health.flowApp</string>
+	</array>
+</dict>
+</plist>

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -4,12 +4,13 @@ import ProjectDescriptionHelpers
 let project = Project(
     name: "FlowApp",
     organizationName: flowOrganizationName,
+    settings: .settings(base: .codeSign),
     targets: [
         .target(
             name: "FlowApp",
             destinations: .iOS,
             product: .app,
-            bundleId: "\(flowOrganizationName).flowApp",
+            bundleId: "\(flowOrganizationName).flow-App",
             deploymentTargets: .iOS("17.0"),
             infoPlist: .extendingDefault(with: uiKitPlist),
             sources: [
@@ -17,6 +18,7 @@ let project = Project(
                 "Intent/Sources/**"
             ],
             resources: ["Resources/**"],
+            entitlements: .file(path: "Entitlements/FlowApp.entitlements"),
             dependencies: [
                 .Module.flowKit,
                 .Module.flowService,
@@ -27,12 +29,14 @@ let project = Project(
             name: "FlowWidgetExtension",
             destinations: .iOS,
             product: .appExtension,
-            bundleId: "\(flowOrganizationName).flowApp.flowWidgetExtension",
+            bundleId: "\(flowOrganizationName).flow-App.flowWidget-Extension",
+            deploymentTargets: .iOS("17.0"),
             infoPlist: .extendingDefault(with: widgetPlist),
             sources: [
                 "Widget/Sources/**",
                 "Intent/Sources/**"
             ],
+            entitlements: .file(path: "Widget/Entitlements/FlowWidgetExtension.entitlements"),
             dependencies: [
                 .Module.flowKit,
                 .Module.flowService

--- a/Projects/App/Widget/Entitlements/FlowWidgetExtension.entitlements
+++ b/Projects/App/Widget/Entitlements/FlowWidgetExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.flow-health.flowApp</string>
+	</array>
+</dict>
+</plist>

--- a/Projects/Modules/LocalService/Sources/DataBase/DataBaseManager.swift
+++ b/Projects/Modules/LocalService/Sources/DataBase/DataBaseManager.swift
@@ -38,8 +38,10 @@ final class DataBaseManager {
     private init() {
         do {
             let fileSystem = FileManager.default
-            let fileURL = fileSystem.urls(for: .documentDirectory, in: .userDomainMask)[0]
-                .appending(path: "SQlite", directoryHint: .isDirectory)
+            guard let fileURL = fileSystem.containerURL(forSecurityApplicationGroupIdentifier: "group.com.flow-health.flowApp")?
+                .appending(path: "SQlite", directoryHint: .isDirectory) else {
+                fatalError("fail to fileURL")
+            }
             try? fileSystem.createDirectory(at: fileURL, withIntermediateDirectories: false)
             let dbURL = fileURL.appending(path: "db.sqlite3")
 

--- a/Tuist/ProjectDescriptionHelpers/CodeSign.swift
+++ b/Tuist/ProjectDescriptionHelpers/CodeSign.swift
@@ -1,0 +1,7 @@
+import ProjectDescription
+
+extension SettingsDictionary {
+    public static let codeSign = SettingsDictionary()
+        .codeSignIdentityAppleDevelopment()
+        .automaticCodeSigning(devTeam: "Z25H7B85Z8")
+}


### PR DESCRIPTION
## 개요
> 기록 작성버그 수정

## 설명 
- 위젯에서 기록할 때, 데이터가 기록될때도 있고 안될때도 있는 버그가 발생
- 기록된 DB기록을 확인해본 결과 WidgetExtension과 app의 db.sqlite3 파일 경로가 다른 것을 확인
- WidgetExtension와 app이 다른 SandBox였기 때문에 문제가 생긴 것으로 파악
- appGroup을 사용하여 공유 SandBox를 만들어 문제 해결

## 변경 로직 
- 기존 Documents/SQlite/db.sqlite3의 경로로 db.sqlite3파일 위치 저장 -> appGroup의 Documents/SQlite/db.sqlite3 경로로 접근하도록 변경