### PR TITLE
🔀 :: (#55) 중복 호출 버그 수정

### DIFF
--- a/Projects/App/Sources/Scene/Search/SearchViewModel.swift
+++ b/Projects/App/Sources/Scene/Search/SearchViewModel.swift
@@ -32,7 +32,9 @@ class SearchViewModel: ViewModelType, Stepper {
         let searchMedicine = PublishRelay<[MedicineInfoEntity]>()
 
         input.searchInputText
+            .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
+            .distinctUntilChanged()
             .debounce(.milliseconds(600), scheduler: MainScheduler.asyncInstance)
             .flatMap {
                 self.searchMedicineUseCase.execute(with: $0)

--- a/Projects/Modules/Model/Sources/DTO/Response/MedicineInfoResponse.swift
+++ b/Projects/Modules/Model/Sources/DTO/Response/MedicineInfoResponse.swift
@@ -37,19 +37,25 @@ public struct MedicineInfoResponse: Decodable {
 public extension MedicineInfoResponse {
     func toDomain() -> MedicineInfoEntity {
         return .init(
-            imageURL: imageURL ?? "-",
-            medicineName: medicineName ?? "-",
-            companyName: companyName ?? "-",
-            itemCode: itemCode ?? "-",
-            efficacy: efficacy ?? "-",
-            howToUse: howToUse ?? "-",
-            cautionWarning: cautionWarning ?? "-",
-            caution: caution ?? "-",
-            interaction: interaction ?? "-",
-            sideEffect: sideEffect ?? "-",
-            storageMethod: storageMethod ?? "-",
-            updateDate: updateDate ?? "-",
+            imageURL: toTrimString(imageURL),
+            medicineName: toTrimString(medicineName),
+            companyName: toTrimString(companyName),
+            itemCode: toTrimString(itemCode),
+            efficacy: toTrimString(efficacy),
+            howToUse: toTrimString(howToUse),
+            cautionWarning: toTrimString(cautionWarning),
+            caution: toTrimString(caution),
+            interaction: toTrimString(interaction),
+            sideEffect: toTrimString(sideEffect),
+            storageMethod: toTrimString(storageMethod),
+            updateDate: toTrimString(updateDate),
             medicineType: .NOMAL
         )
+    }
+
+    private func toTrimString(_ content: String?) -> String {
+        guard let content else { return "-" }
+
+        return content.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }


### PR DESCRIPTION
## 개요
> 검색 API 중복호출 버그 수정

## 작업사항
- 검색어에 trim적용
- .distinctUntilChanged() 적용으로 같은 검색어 중복검색 방지
- detail화면의 설명들 trim 적용

close #55 